### PR TITLE
Fix OpenUI docs and repo links per maintainer feedback (closes #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Build production generative UI applications with OpenUI. Any LLM provider. Any b
 
 ## What is this?
 
-OpenUI Forge is an agent skill that helps you build generative UI applications using [OpenUI](https://docs.openui.dev/), a streaming-first framework where LLMs output a compact DSL (OpenUI Lang) instead of JSON or HTML. The result: 67% fewer tokens, progressive rendering as tokens arrive, and graceful handling of hallucinated components.
+OpenUI Forge is an agent skill that helps you build generative UI applications using [OpenUI](https://docs.thesys.dev/), a streaming-first framework where LLMs output a compact DSL (OpenUI Lang) instead of JSON or HTML. The result: 67% fewer tokens, progressive rendering as tokens arrive, and graceful handling of hallucinated components.
 
 This skill covers the full development lifecycle: scaffolding new projects, creating components with Zod schemas, integrating any LLM backend (OpenAI, Anthropic, LangChain, Vercel AI), supporting non-JS backends (Python, Go, Rust), and validating the entire stack.
 
@@ -114,8 +114,8 @@ Live UI          <-- Parser          <-- Adapter
 
 ## Links
 
-- [OpenUI Documentation](https://docs.openui.dev/)
-- [OpenUI GitHub](https://github.com/openuidev)
+- [OpenUI Documentation](https://docs.thesys.dev/)
+- [OpenUI GitHub](https://github.com/thesysdev/openui)
 - [skills.sh](https://skills.sh/)
 - [Author Portfolio](https://othmanadi.com)
 


### PR DESCRIPTION
## Summary

Updates broken OpenUI references in the README, flagged by @vishxrad (OpenUI maintainer) in #1.

- `https://docs.openui.dev/` becomes `https://docs.thesys.dev/` (intro paragraph and Links section)
- `https://github.com/openuidev` becomes `https://github.com/thesysdev/openui` (Links section)

The `@openuidev/*` NPM package scope is unchanged: those are the published package names maintained by the thesys.dev team and remain accurate.

## Test plan

- [x] grep for `docs.openui.dev` returns no matches
- [x] grep for `github.com/openuidev` returns no matches (NPM scope `@openuidev/*` retained, verified against npm registry)
- [x] Links resolve: docs.thesys.dev (OpenUI docs), github.com/thesysdev/openui (canonical repo)

Closes #1